### PR TITLE
Syntax error in the site configuration file preventing login and playback

### DIFF
--- a/Contents/Site Configurations/amazoninstantvideo.xml
+++ b/Contents/Site Configurations/amazoninstantvideo.xml
@@ -31,8 +31,8 @@
             </condition>
             <action>
                 <pause time="500" />
-                <run script="document.getElementsByName('email')[0].value='{$username}'" />
-                <run script="document.getElementsByName('password')[0].value='{$password}'" />
+                <run script="document.getElementsByName('email')[0].value='${email}'" />
+                <run script="document.getElementsByName('password')[0].value='${password}'" />
                 <run script="document.forms[0].submit()" />
                 <pause time="500" />
                 <goto state="reload" />


### PR DESCRIPTION
I fixed a syntax error in the site configuration file relating to the user preferences. The $ sign should be outside the curly braces. I also changed username variable from username to email so that it matches the id specified in the ServicePrefs.json file.
